### PR TITLE
ChangeLog: Replaced argument '--parallel' with '--threads'. Utilized …

### DIFF
--- a/chromosearch.py
+++ b/chromosearch.py
@@ -22,7 +22,7 @@ def main(fasta_path,
          database, 
          process=True, 
          save_intermediates=True, 
-         parallel=True, 
+         threads=1, 
          matrix=True, 
          match=3, 
          mismatch=-1, 
@@ -74,7 +74,7 @@ def main(fasta_path,
         pbs(f'{output_dir}/output_{gene}_DNAtoProtein.fasta',
             gene,
             temp_protein_search,
-            input_database=f'{database}')
+            input_database=f'{database}', threads = threads)
         
         print_quiet_mode(f'pbs: finished')
 
@@ -89,10 +89,9 @@ def main(fasta_path,
 
         print_quiet_mode(f'smith waterman + name_and_sequence_pair started...')
         sequence_pairs = nm(f'{output_dir}/output_{gene}_DNAtoProtein.fasta', f'{output_dir}/output_{gene}_sorted_pBLAST.csv', input_database_fasta=f'{database}.fasta', blastpsw=blastpnsw)
-        
         print_quiet_mode(f'Performing the Smith-Waterman algorithm on {len(sequence_pairs)} sequence pairs...')
 
-        sm(output_dir, gene_name=gene, sequence_pairs=sequence_pairs, parallel=parallel, matrix=matrix, match=match, mismatch=mismatch, gap_open=gap_open, gap_extend=gap_extend)
+        sm(output_dir, gene_name=gene, sequence_pairs=sequence_pairs, threads=threads, matrix=matrix, match=match, mismatch=mismatch, gap_open=gap_open, gap_extend=gap_extend)
         print_quiet_mode(f'smith waterman + name_and_sequence_pair finished')
 
         csv_sorter(f'{output_dir}/output_{gene}_smith_waterman.csv', gene, temp_SW_csv, only_sort=True, sort_value_metric='Score', name_output='sorted_alignment')
@@ -119,7 +118,7 @@ if __name__ == "__main__":
     parser.add_argument("output_path", help="Path to where to save the output files")
     parser.add_argument("gene", help="Name of the gene to process")
     parser.add_argument("-db", "--database", default='databases/chromoproteins_uniprot/uniprotkb_chromophore_keyword_KW_0157_AND_reviewed_2024_06_24', help="Path to the chromoprotein database")
-    parser.add_argument("-p", "--parallel", action="store_false", help="If you want to disable the parallelization")
+    parser.add_argument("-t", "--threads", type = int, default=1, help="Number of threads available to the pipeline. Set to 0 or negative numbers to use all available cores")
     parser.add_argument("-M", "--matrix", action="store_false", help="If you want to disable BLOSUM62 matrix and use standard scores")
     parser.add_argument("--match", type=int, default=3, help="Score for a match")
     parser.add_argument("--mismatch", type=int, default=-1, help="Penalty for a mismatch")
@@ -137,7 +136,6 @@ if __name__ == "__main__":
     gene_argument = args.gene
     database_argument = args.database
     save_intermediates_argument = args.save_intermediates
-    parallel_argument = args.parallel
     matrix_argument = args.matrix
     match_argument = args.match
     mismatch_argument = args.mismatch
@@ -147,6 +145,17 @@ if __name__ == "__main__":
     blastpnsw_argument = args.blastpandsmithwaterman
     quiet_argument = args.quiet
 
+    # check options for threads arg
+    # assign all available cpus
+    if args.threads <= 0:
+        threads = os.cpu_count()
+    elif args.threads > os.cpu_count():
+        raise Exception("Number of threads specified exceeds those available in the system. Please specify a lower count, or run single-threaded")
+    else:
+        threads = args.threads
+
+    if threads == 1:
+        print("You have chosen to run the pipeline using only 1 thread. This might take some time...\n")
 
 
     main(fasta_path=fasta_path_argument, 
@@ -154,7 +163,7 @@ if __name__ == "__main__":
          gene=gene_argument, 
          database=database_argument, 
          process=process_argument, save_intermediates=save_intermediates_argument, 
-         parallel=parallel_argument, matrix=matrix_argument, 
+         threads=threads, matrix=matrix_argument,
          match=match_argument, 
          mismatch=mismatch_argument, 
          gap_open=gap_open_argument, 

--- a/scripts/protein_search.py
+++ b/scripts/protein_search.py
@@ -5,14 +5,15 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def protein_blastp_search(input_sequence, genome, output, input_database):
+def protein_blastp_search(input_sequence, genome, output, input_database, threads):
     logger.debug('Entering protein_blastp_search function')
     # Generate the BLASTP command
     blastp_command = [
         'blastp',
         '-db', input_database,
         '-outfmt', '6 qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore',
-        '-query', input_sequence
+        '-query', input_sequence,
+        '-num_threads', str(threads)
     ]
 
     output_csv_file = f'{output}/output_{genome}_protein_search.csv'

--- a/scripts/smith_waterman.py
+++ b/scripts/smith_waterman.py
@@ -1,132 +1,128 @@
 import csv
 import logging
-from Bio.Align import substitution_matrices
 import concurrent.futures as futures
 from functools import partial
+from itertools import islice
 from Bio.Align import PairwiseAligner
+from Bio.Align import substitution_matrices
 
 logger = logging.getLogger(__name__)
 
-def matrix_sw_parall(match, mismatch, gap_open, gap_extend, sequence_pairs):
+def sequence_pairs_smith_waterman(match, mismatch, gap_open, gap_extend, matrix, sequence_pairs):
+    """Basic funtion that takes a list of sequence_pairs and returns their names along with their scores. Used by smith_waterman_alignment().
 
-    ## Used when you want to parallelize the alignment with BLOSUM62 matrix
+    Args:
+        match (int): Score for match
+        mismatch (_type_): Score for mismatch
+        gap_open (_type_): Penalty for gap opening
+        gap_extend (_type_): Penalty for gap extension
+        sequence_pairs (_type_): List of sequence pairs, format [[(name1, seq1), (name2, seq_2)], ...]
+    Returns:
+        list: List of dictionaries, each with the format {'Name1': name1, 'Name2': name2, 'Score': score}.
+    """   
 
+    # Basic alignment setup
     aligner = PairwiseAligner()
     aligner.mode = 'local'
-    aligner.match_score = match        # Match score
-    aligner.mismatch_score = mismatch    # Mismatch penalty
-    aligner.open_gap_score = gap_open   # Gap opening penalty
-    aligner.extend_gap_score = gap_extend # Gap extension penalty
-    aligner.substitution_matrix = substitution_matrices.load("BLOSUM62")
+    aligner.match_score = match        
+    aligner.mismatch_score = mismatch    
+    aligner.open_gap_score = gap_open   
+    aligner.extend_gap_score = gap_extend 
 
-    (name1, seq1), (name2, seq2) = sequence_pairs
-    try:
-        best_alignment = aligner.align(seq1, seq2)[0]
-        score = best_alignment.score
+    # TO IMPLEMENT: SUPPORT OTHER MATRICES 
+    if matrix is not None:
+        aligner.substitution_matrix = substitution_matrices.load("BLOSUM62")
 
-    except Exception as e:
-        logger.error(f'Error in matrix_sw_parall function: {e}')
+    # List of dirs to return
+    results_list = []
 
-    except KeyboardInterrupt:
-        logger.warning("Data processing interrupted by user")
+    for pair in sequence_pairs:
+        (name1, seq1), (name2, seq2) = pair
+        try:
+            best_alignment = aligner.align(seq1, seq2)[0]
+            score = best_alignment.score
 
-    return {'Name1': name1, 'Name2': name2, 'Score': score}
+        except Exception as e:
+            logger.error(f'Error in sequence_pair_smith_waterman(), for sequences {name1}, {name2}: {e}')
 
+        except KeyboardInterrupt:
+            logger.warning("Data processing interrupted by user.")
 
-def raw_sw_parall(match, mismatch, gap_open, gap_extend, sequence_pairs):
+        # This is the most inefficient data structure ever created
+        results_list.append({'Name1': name1, 'Name2': name2, 'Score': score})
 
-    ## Used when you want to parallelize the alignment using scoring system
-
-    aligner = PairwiseAligner()
-    aligner.mode = 'local'
-    aligner.match_score = match        # Match score
-    aligner.mismatch_score = mismatch    # Mismatch penalty
-    aligner.open_gap_score = gap_open   # Gap opening penalty
-    aligner.extend_gap_score = gap_extend # Gap extension penalty
-
-    (name1, seq1), (name2, seq2) = sequence_pairs
-    try:
-        best_alignment = aligner.align(seq1, seq2)[0]
-        score = best_alignment.score
-
-    except Exception as e:
-        logger.error(f'Error in raw_sw_parall function: {e}')
-
-    except KeyboardInterrupt:
-        logger.warning("Data processing interrupted by user")
-
-    return {'Name1': name1, 'Name2': name2, 'Score': score}
+    return results_list
 
 
-def smith_waterman_alignment(output, sequence_pairs, gene_name, parallel=True, match=3, mismatch=-1, gap_open=-10, gap_extend=-4, matrix=True):
-    logger.debug('Entering smith_waterman_alignment function')
-    try:
-        with open(f'{output}/output_{gene_name}_smith_waterman.csv', 'w', newline='') as csvfile:
+# NOTE: Changed from one pair = one process to batch processing
+def batch_sequence_pairs(sequence_pairs, threads):
+    """Creates the sequence pairs for the batch process
 
+    Args:
+        sequence_pairs (list): List of sequence pairs, format [[(name1, seq1), (name2, seq_2)], ...]
+        threads (int): Number of threads.
+
+    Returns:
+        list: List of sequence pairs batches.
+    """
+
+    CHUNK_SIZE = len(sequence_pairs) // threads
+    
+    # Uses generator for memory efficiency
+    it = iter(sequence_pairs)
+    while True:
+        batch = list(islice(it, CHUNK_SIZE))
+        if not batch:
+            return
+        yield batch
+
+def write_smith_waterman_results(output, gene_name, results_dictonaries):
+    """Function to write the results of the Waterman-Smith alignment into a .csv file.
+
+    Args:
+        output (str): Output file location.
+        gene_name (str): Naming prefix for the results.
+        results_dir (): List of dictionaries to write out.
+    """
+
+    with open(f'{output}/output_{gene_name}_smith_waterman.csv', 'w', newline='') as csvfile:
+        
+        try:
             fieldnames = ['Name1', 'Name2', 'Score']
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
             writer.writeheader()
 
-            if matrix and parallel:
-                logger.debug('Entered matrix and parallel')
-                partial_matrix_sw_parall = partial(matrix_sw_parall, match, mismatch, gap_open, gap_extend)
-                with futures.ProcessPoolExecutor() as ex:
-                    result = list(ex.map(partial_matrix_sw_parall, sequence_pairs))
-                    for i in result:
-                        writer.writerow(i)
+            # Write all results
+            for result in results_dictonaries:
+                writer.writerow(result)
+        
+        except Exception as e:
+            logger.error(f'Error in function write_smith_waterman_results(): {e}')
 
-            elif matrix and not parallel:
-                logger.debug('Entered matrix and NOT parallel')
-                
-                aligner = PairwiseAligner()
-                aligner.mode = 'local'
-                aligner.match_score = match        # Match score
-                aligner.mismatch_score = mismatch    # Mismatch penalty
-                aligner.open_gap_score = gap_open   # Gap opening penalty
-                aligner.extend_gap_score = gap_extend # Gap extension penalty
-                aligner.substitution_matrix = substitution_matrices.load("BLOSUM62")
+    return
 
-                for (name1, seq1), (name2, seq2) in sequence_pairs:
-                    try:
-                        best_alignment = aligner.align(seq1, seq2)[0]
-                        score = best_alignment.score
-                    except Exception as e:
-                        logger.error(f'Error in smith_waterman_alignment function: {e}')
-                    except KeyboardInterrupt:
-                        logger.warning("Data processing interrupted by user")
-                    
-                    writer.writerow({'Name1': name1, 'Name2': name2, 'Score': score})
+def smith_waterman_alignment(output, sequence_pairs, gene_name, match=3, mismatch=-1, gap_open=-10, gap_extend=-4, matrix=True, threads= 1):
 
-            elif parallel and not matrix:
-                logger.debug('Entered parallel and NOT matrix')
-                partial_raw_sw_parall = partial(raw_sw_parall, match, mismatch, gap_open, gap_extend)
-                with futures.ProcessPoolExecutor() as ex:
-                    result = list(ex.map(partial_raw_sw_parall, sequence_pairs))
-                for i in result:
-                    print(i)
-                    writer.writerow(i)
-            else:
-                logger.debug('Entered NOT matrix and NOT parallel')
-                
-                aligner = PairwiseAligner()
-                aligner.mode = 'local'
-                aligner.match_score = match        # Match score
-                aligner.mismatch_score = mismatch    # Mismatch penalty
-                aligner.open_gap_score = gap_open   # Gap opening penalty
-                aligner.extend_gap_score = gap_extend # Gap extension penalty
+    logger.debug('Entering smith_waterman_alignment function')
 
-                for (name1, seq1), (name2, seq2) in sequence_pairs:
-                    try:
-                        best_alignment = aligner.align(seq1, seq2)[0]
-                        score = best_alignment.score
-                    except Exception as e:
-                        logger.error(f'Error in smith_waterman_alignment function: {e}')
-                    except KeyboardInterrupt:
-                        logger.warning("Data processing interrupted by user")
-                    
-                    writer.writerow({'Name1': name1, 'Name2': name2, 'Score': score})
-                    
-        logger.info(f'Result from smith_waterman_alignment function saved in: output_{gene_name}_smith_waterman.csv')
+    result_to_write = []
+    try:
+        # Single-threaded mode
+        if threads == 1:
+            logger.debug('Entered single-threaded mode...')
+            result_to_write = sequence_pairs_smith_waterman(match, mismatch, gap_open, gap_extend, sequence_pairs, matrix)
+            
+        else:
+            logger.debug('Entered multi-threaded mode...')
+
+            # Set the first arguments for the function as static, and map to the batch sequence pairs
+            partial_sequence_pair_smith_waterman = partial(sequence_pairs_smith_waterman, match, mismatch, gap_open, gap_extend, matrix)
+            with futures.ProcessPoolExecutor() as ex:
+                result = list(ex.map(partial_sequence_pair_smith_waterman, batch_sequence_pairs(sequence_pairs, threads)))
+            
+            # flatten result list of lists of dictionaries
+            # Could retain use of a generator if memory is a problem - Unlikely
+            result_to_write = [item for sublist in result for item in sublist]
 
     except Exception as e:
         logger.error(f'Error in smith_waterman_alignment function: {e}')
@@ -134,4 +130,9 @@ def smith_waterman_alignment(output, sequence_pairs, gene_name, parallel=True, m
     except KeyboardInterrupt:
         logger.warning("Data processing interrupted by user")
 
-    logger.debug('Exiting smith_waterman_alignment function')
+    logger.debug("Waterman-Smith finished, writing results...")
+
+    # Write results to file
+    write_smith_waterman_results(output, gene_name, result_to_write)
+
+    return


### PR DESCRIPTION
…multithreading in BLASTP protein_search function. Used batch multithreading for Waterman-Smith alignment, instead of creating a process for each pair of sequences. All mutlithreaded options where transfered to '--threads', with 0 or negative numbers translating to all available ones, similar to old '--parallel'